### PR TITLE
adds autofixing and the ability to specify a custom module

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,25 @@ You'll first need to install [ESLint](http://eslint.org):
 $ npm i eslint --save-dev
 ```
 
+If using yarn:
+
+```
+yarn add --dev eslint
+```
+
 Next, install `eslint-plugin-ember-a11y-testing`:
 
 ```
 $ npm install eslint-plugin-ember-a11y-testing --save-dev
 ```
 
-**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-ember-a11y-testing` globally.
+If using yarn:
+
+```
+$ yarn add --dev eslint-plugin-ember-a11y-testing
+```
+
+**Note:** If you installed ESLint globally (using the `-g` flag with `npm`, or `yarn global` with yarn) then you must also install `eslint-plugin-ember-a11y-testing` globally.
 
 ## Usage
 
@@ -42,11 +54,58 @@ Or extend the recommended config:
 }
 ```
 
-Or configure the rules you want to use under the rules section. 
+Or configure the rules you want to use under the rules section.
 ```json
 {
   "rules": {
     "ember-a11y-testing/a11y-audit": "error"
   }
 }
+```
+
+### Using a custom audit module
+
+By default, `eslint-plugin-ember-a11y-testing` expects you to define imports
+for `a11yAudit` in your tests as listed on the [ember-a11y-testing
+README](https://github.com/ember-a11y/ember-a11y-testing#acceptance-tests):
+
+```javascript
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+```
+
+However, sometimes it's handy to combine `a11yAudit` with your own setup
+code, or keep configuration for aXe in one place. In that case, you can tell
+`eslint-plugin-ember-a11y-testing` that you'd like to use a different module:
+
+```json
+{
+  "plugins": ["ember-a11y-testing"],
+  "settings": {
+    "ember-a11y-testing": {
+      "auditModule": {
+        "package": "my-app/tests/helpers/audit",
+        "exportName": "default"
+      }
+    }
+  }
+}
+```
+
+```javascript
+// your module defined at tests/helpers/audit.js
+import a11yAudit from 'ember-a11y-testing/test-support/audit';
+
+export default async function audit() {
+  const axeOptions = {
+    // redacted for brevity
+  }
+  await a11yAudit(axeOptions);
+}
+```
+
+`eslint-plugin-ember-a11y-testing` will then expect you to import from that
+module like so:
+
+```javascript
+import a11yAudit from 'my-app/tests/helpers/audit';
 ```

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -12,6 +12,14 @@ module.exports = {
   },
 
   plugins: ["ember-a11y-testing"],
+  settings: {
+    "ember-a11y-testing": {
+      "auditModule": {
+        "package": 'ember-a11y-testing/test-support/audit',
+        "exportName": 'default'
+      }
+    }
+  },
 
   rules: {
     "ember-a11y-testing/a11y-audit": "error",

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -15,6 +15,7 @@ module.exports = {
 
   rules: {
     "ember-a11y-testing/a11y-audit": "error",
-    "ember-a11y-testing/a11y-audit-after-test-helper": "error"
+    "ember-a11y-testing/a11y-audit-after-test-helper": "error",
+    "ember-a11y-testing/a11y-audit-no-expression": "error"
   }
 };

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -16,6 +16,7 @@ module.exports = {
   rules: {
     "ember-a11y-testing/a11y-audit": "error",
     "ember-a11y-testing/a11y-audit-after-test-helper": "error",
-    "ember-a11y-testing/a11y-audit-no-expression": "error"
+    "ember-a11y-testing/a11y-audit-no-expression": "error",
+    "ember-a11y-testing/a11y-audit-no-globals": "error"
   }
 };

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -95,7 +95,7 @@ module.exports = {
     const excludeFunctionNames = options.exclude;
 
     const declaration = utils.findA11yAuditImportDeclaration(context, settings);
-    const a11yAuditIdentifier = declaration ? declaration.local.name : 'a11yAudit';
+    const a11yAuditIdentifier = declaration ? declaration.local.name : utils.DEFAULT_A11Y_AUDIT_VARIABLE;
 
     const functionSelectors = []
       .concat(defaultTestHelperFunctions, includeFunctionNames)
@@ -156,7 +156,7 @@ module.exports = {
               let fixerNode = node;
               let parentFn = utils.findParentOfType(node, /FunctionDeclaration/);
               let prefix = parentFn && parentFn.async ? 'await ' : '';
-              return fixer.insertTextAfter(fixerNode, `; ${prefix}${a11yAuditIdentifier || 'a11yAudit'}()`);
+              return fixer.insertTextAfter(fixerNode, `; ${prefix}${a11yAuditIdentifier}()`);
             }
           });
         }

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -76,11 +76,23 @@ module.exports = {
       "fillIn"
     ];
 
-    const config = utils.buildConfig(context.options);
+    const config = utils.buildConfig(context.settings);
 
-    const includeFunctionNames = config.include;
+    const extractOptions = (rawConfig) => {
+      if (!Array.isArray(rawConfig)) {
+        return extractOptions([]);
+      }
+      const config = rawConfig[0] || {};
+      return {
+        include: [],
+        exclude: [],
+        ...config
+      };
+    }
+    const options = extractOptions(context.options);
+    const includeFunctionNames = options.include;
 
-    const excludeFunctionNames = config.exclude;
+    const excludeFunctionNames = options.exclude;
 
     const declaration = utils.findA11yAuditImportDeclaration(context, config);
     const a11yAuditIdentifier = declaration ? declaration.local.name : 'a11yAudit';

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -82,18 +82,7 @@ module.exports = {
 
     const excludeFunctionNames = config.exclude;
 
-    const importDeclaration = context.getSourceCode().ast.body.find(({type, specifiers, source}) => {
-      return type === 'ImportDeclaration' && source.value === config.auditModule.package;
-    });
-
-    const declaration = importDeclaration && importDeclaration.specifiers.find((specifier) => {
-      if (config.auditModule.exportName === 'default') {
-        return specifier.type === 'ImportDefaultSpecifier';
-      } else {
-        return specifier.type === 'ImportSpecifier' && specifier.imported.name === config.auditModule.exportName;
-      }
-    });
-
+    const declaration = utils.findA11yAuditImportDeclaration(context, config);
     const a11yAuditIdentifier = declaration ? declaration.local.name : 'a11yAudit';
 
     const functionSelectors = []

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -163,7 +163,7 @@ module.exports = {
                 }
               }
               let fixerNode = node;
-              let parentFn = utils.findParentOfType(node, /FunctionDeclaration/);
+              let parentFn = utils.findParentOfType(node, /Function/);
               let prefix = parentFn && parentFn.async ? 'await ' : '';
               return fixer.insertTextAfter(fixerNode, `; ${prefix}${a11yAuditIdentifier}()`);
             }

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -69,11 +69,20 @@ module.exports = {
       "blur",
       "click",
       "doubleClick",
+      "fillIn",
       "focus",
       "tap",
       "triggerEvent",
       "triggerKeyEvent",
-      "fillIn"
+      "typeIn",
+
+      // rendering helpers
+      "render",
+
+      // TODO: decide if wait helpers would be handy to audit
+      // "waitFor",
+      // "waitUntil",
+      // "settled"
     ];
 
     const settings = utils.extractSettings(context);

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const utils = require('../utils');
+
 /**
  * @fileoverview Enforce calling a11yAudit after test helpers
  * in acceptance tests
@@ -17,7 +19,8 @@
 
 module.exports = {
   meta: {
-    type: "suggestion",
+    type: "problem",
+    fixable: "code",
 
     description: "enforce calling a11yAudit after test helpers in acceptance tests",
     category: "Accessibility",
@@ -42,7 +45,13 @@ module.exports = {
       }
     }],
 
+    parserOptions: {
+      "ecmaVersion": 2017,
+      "sourceType": "module"
+    },
+
     messages: {
+      a11yAuditMustBeCalled: "a11yAudit must be called as a function and can't be used as a value. Replace `a11yAudit` with added parens, e.g. `a11yAudit()`",
       a11yAuditAfterHelper: "Call a11yAudit after acceptance test helper"
     }
   },
@@ -63,22 +72,29 @@ module.exports = {
       "focus",
       "tap",
       "triggerEvent",
-      "triggerKeyEvent"
+      "triggerKeyEvent",
+      "fillIn"
     ];
 
-    const includeFunctionNames =
-      Array.isArray(context.options) &&
-      context.options[0] &&
-      Array.isArray(context.options[0].include)
-        ? context.options[0].include
-        : [];
+    const config = utils.buildConfig(context.options);
 
-    const excludeFunctionNames =
-      Array.isArray(context.options) &&
-      context.options[0] &&
-      Array.isArray(context.options[0].exclude)
-        ? context.options[0].exclude
-        : [];
+    const includeFunctionNames = config.include;
+
+    const excludeFunctionNames = config.exclude;
+
+    const importDeclaration = context.getSourceCode().ast.body.find(({type, specifiers, source}) => {
+      return type === 'ImportDeclaration' && source.value === config.auditModule.package;
+    });
+
+    const declaration = importDeclaration && importDeclaration.specifiers.find((specifier) => {
+      if (config.auditModule.exportName === 'default') {
+        return specifier.type === 'ImportDefaultSpecifier';
+      } else {
+        return specifier.type === 'ImportSpecifier' && specifier.imported.name === config.auditModule.exportName;
+      }
+    });
+
+    const a11yAuditIdentifier = declaration ? declaration.local.name : 'a11yAudit';
 
     const functionSelectors = []
       .concat(defaultTestHelperFunctions, includeFunctionNames)
@@ -88,7 +104,7 @@ module.exports = {
 
     return {
       ["CallExpression" + functionSelectors]: function(node) {
-        const parentExpressionStatementNode = findExpressionParent(node);
+        const parentExpressionStatementNode = utils.findParentOfType(node, 'ExpressionStatement');
 
         const nextToken = context
           .getSourceCode()
@@ -99,38 +115,51 @@ module.exports = {
           : null;
 
         const nextNodeExists = Boolean(nextNode);
-        const nextNodeIsA11yAudit = nextNodeExists
-          ? nextNode.name === "a11yAudit"
-          : false;
 
-        // check if the next node is being called with parens, ie: click()
-        const nextNodeHasCallExpression = nextNodeExists
-          ? nextNode.parent.type === "CallExpression"
-          : false;
+        const isA11yAudit = (node) => {
+          if (!node) {
+            return false;
+          }
+          if (node.parent && node.parent.type === 'CallExpression') {
+            return node.parent.callee.type === 'Identifier' && node.parent.callee.name === a11yAuditIdentifier;
+          } else if (node.type === 'AwaitExpression' && node.argument.type === 'CallExpression') {
+            return node.argument.callee.type === 'Identifier' && node.argument.callee.name === a11yAuditIdentifier;
+          }
+        }
+        const nextNodeIsA11yAudit = nextNodeExists && isA11yAudit(nextNode);
 
         if (
           !nextNodeExists ||
-          !nextNodeIsA11yAudit ||
-          !nextNodeHasCallExpression
+          !nextNodeIsA11yAudit
         ) {
           context.report({
             node,
-            messageId: "a11yAuditAfterHelper"
+            messageId: "a11yAuditAfterHelper",
+            fix(fixer) {
+              // don't attempt to autofix when helper is passed to a function, e.g.
+              // assert.throws(fillIn('#foo', 'hi))
+              if (node.parent.type === 'CallExpression') {
+                return;
+              }
+              if (nextNode) {
+                // don't autofix `a11yAudit` (e.g. without parens/not a call expression)
+                // it should get autofixed by a11y-audit-no-expression instead.
+                if(nextNode.type === 'ExpressionStatement' && nextNode.expression.type === 'Identifier' && nextNode.expression.name === a11yAuditIdentifier) {
+                  return
+                } else if (nextNode.type === 'AwaitExpression') {
+                  if (nextNode.argument.type === 'Identifier' && nextNode.argument.name === a11yAuditIdentifier) {
+                    return
+                  }
+                }
+              }
+              let fixerNode = node;
+              let parentFn = utils.findParentOfType(node, /FunctionDeclaration/);
+              let prefix = parentFn && parentFn.async ? 'await ' : '';
+              return fixer.insertTextAfter(fixerNode, `; ${prefix}${a11yAuditIdentifier || 'a11yAudit'}()`);
+            }
           });
         }
       }
     };
   }
 };
-
-function findExpressionParent(node) {
-  if (node.type === "ExpressionStatement") {
-    return node;
-  }
-
-  if (!node) {
-    return node;
-  }
-
-  return findExpressionParent(node.parent);
-}

--- a/lib/rules/a11y-audit-after-test-helper.js
+++ b/lib/rules/a11y-audit-after-test-helper.js
@@ -76,7 +76,7 @@ module.exports = {
       "fillIn"
     ];
 
-    const config = utils.buildConfig(context.settings);
+    const settings = utils.extractSettings(context);
 
     const extractOptions = (rawConfig) => {
       if (!Array.isArray(rawConfig)) {
@@ -94,7 +94,7 @@ module.exports = {
 
     const excludeFunctionNames = options.exclude;
 
-    const declaration = utils.findA11yAuditImportDeclaration(context, config);
+    const declaration = utils.findA11yAuditImportDeclaration(context, settings);
     const a11yAuditIdentifier = declaration ? declaration.local.name : 'a11yAudit';
 
     const functionSelectors = []

--- a/lib/rules/a11y-audit-no-expression.js
+++ b/lib/rules/a11y-audit-no-expression.js
@@ -16,10 +16,10 @@ module.exports = {
     schema: []
   },
   create(context) {
-    const config = utils.buildConfig(context.settings);
+    const settings = utils.extractSettings(context);
     return {
       ExpressionStatement: function(node) {
-        const a11yIdentifier = findA11yAuditIdentifier(node.expression, context, config);
+        const a11yIdentifier = findA11yAuditIdentifier(node.expression, context, settings);
         if (node.expression.type === "Identifier" && node.expression.name === a11yIdentifier) {
           context.report({
             node,
@@ -33,7 +33,7 @@ module.exports = {
         }
       },
       AwaitExpression: function(node) {
-        const a11yIdentifier = findA11yAuditIdentifier(node.argument, context, config);
+        const a11yIdentifier = findA11yAuditIdentifier(node.argument, context, settings);
         if (node.argument && node.argument.type === "Identifier" && node.argument.name === a11yIdentifier) {
           context.report({
             node,
@@ -67,17 +67,17 @@ module.exports = {
 
   import { a11yAudit as foo } from 'package';
 */
-function findA11yAuditIdentifier(node, context, config) {
+function findA11yAuditIdentifier(node, context, settings) {
   const defaultImportVariableName = 'a11yAudit'
   const ref = context.getScope(node).references.find(({identifier: { name }, }) => name === node.name);
   if (!ref || !ref.resolved) return defaultImportVariableName;
   const def = ref.resolved.defs.find((def) => {
     const { type } = def
     if (type === 'ImportBinding') {
-      if (config.auditModule.exportName === 'default') {
-        return def.node.type === 'ImportDefaultSpecifier' && def.parent.source.value === config.auditModule.package;
+      if (settings.auditModule.exportName === 'default') {
+        return def.node.type === 'ImportDefaultSpecifier' && def.parent.source.value === settings.auditModule.package;
       } else  {
-        return def.node.type === 'ImportSpecifier' && def.node.imported.name === config.auditModule.exportName && def.parent.source.value === config.auditModule.package;
+        return def.node.type === 'ImportSpecifier' && def.node.imported.name === settings.auditModule.exportName && def.parent.source.value === settings.auditModule.package;
       }
     }
   });

--- a/lib/rules/a11y-audit-no-expression.js
+++ b/lib/rules/a11y-audit-no-expression.js
@@ -11,31 +11,12 @@ module.exports = {
     url: "https://github.com/jgwhite/eslint-plugin-ember-a11y-testing/blob/master/lib/rules/a11y-audit-no-expression.js",
 
     messages: {
-      a11yAuditMustBeCalled: "a11yAudit must be called as a function and can't be used as a value. Replace `a11yAudit` with added parens, e.g. `a11yAudit()`",
+      a11yAuditMustBeCalled: "a11yAudit must be called as a function. Replace `a11yAudit` with added parens, e.g. `a11yAudit()`",
     },
-    schema: [{
-      "type": "object",
-      "properties": {
-        "auditModule": {
-          "type": "object",
-          "items": {
-            "package": "string",
-            "exportName": "string"
-          }
-        }
-      }
-    }],
+    schema: []
   },
   create(context) {
-    const options = Array.isArray(context.options) ?
-      context.options[0] && context.options[0].auditModule || {} :
-      {};
-
-    const defaults = {
-      package: 'ember-a11y-testing/test-support/audit',
-      exportName: 'default'
-    };
-    const config = {...defaults, ...options};
+    const config = utils.buildConfig(context.settings);
     return {
       ExpressionStatement: function(node) {
         const a11yIdentifier = findA11yAuditIdentifier(node.expression, context, config);
@@ -44,7 +25,7 @@ module.exports = {
             node,
             messageId: "a11yAuditMustBeCalled",
             fix(fixer) {
-              const functionParent = findParentFunction(node);
+              const functionParent = utils.findParentOfType(node, /Function/);
               const prefix = functionParent && functionParent.async ? 'await ' : '';
               return fixer.replaceText(node.expression, `${prefix}${node.expression.name}()`);
             }
@@ -67,18 +48,6 @@ module.exports = {
   }
 };
 
-
-function findParentFunction(node) {
-  if (!node) {
-    return node;
-  }
-  if (node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
-    return node;
-  }
-  return findParentFunction(node.parent);
-}
-
-
 /*
   this is intended to be used to find the name of the emberA11y import name, but in reverse.
   For example:
@@ -89,7 +58,14 @@ function findParentFunction(node) {
           ^ tries to figure out the name of the import
   })
 
-  This makes it so you can copy
+  This makes it so you can use variable bindings:
+
+  // still valid
+  const a11yTest = a11yAudit;
+
+  or rewrite with imports:
+
+  import { a11yAudit as foo } from 'package';
 */
 function findA11yAuditIdentifier(node, context, config) {
   const defaultImportVariableName = 'a11yAudit'
@@ -98,10 +74,10 @@ function findA11yAuditIdentifier(node, context, config) {
   const def = ref.resolved.defs.find((def) => {
     const { type } = def
     if (type === 'ImportBinding') {
-      if (config.exportName === 'default') {
-        return def.node.type === 'ImportDefaultSpecifier' && def.parent.source.value === config.package
+      if (config.auditModule.exportName === 'default') {
+        return def.node.type === 'ImportDefaultSpecifier' && def.parent.source.value === config.auditModule.package;
       } else  {
-        return def.node.type === 'ImportSpecifier' && def.node.imported.name === config.exportName && def.parent.source.value === config.package;
+        return def.node.type === 'ImportSpecifier' && def.node.imported.name === config.auditModule.exportName && def.parent.source.value === config.auditModule.package;
       }
     }
   });

--- a/lib/rules/a11y-audit-no-expression.js
+++ b/lib/rules/a11y-audit-no-expression.js
@@ -68,7 +68,7 @@ module.exports = {
   import { a11yAudit as foo } from 'package';
 */
 function findA11yAuditIdentifier(node, context, settings) {
-  const defaultImportVariableName = 'a11yAudit'
+  const defaultImportVariableName = utils.DEFAULT_A11Y_AUDIT_VARIABLE;
   const ref = context.getScope(node).references.find(({identifier: { name }, }) => name === node.name);
   if (!ref || !ref.resolved) return defaultImportVariableName;
   const def = ref.resolved.defs.find((def) => {

--- a/lib/rules/a11y-audit-no-expression.js
+++ b/lib/rules/a11y-audit-no-expression.js
@@ -1,0 +1,109 @@
+const utils = require('../utils');
+
+module.exports = {
+  meta: {
+    type: "problem",
+    fixable: "code",
+
+    description: "enforce a11yAudit must be called as a function",
+    category: "Accessibility",
+    recommended: true,
+    url: "https://github.com/jgwhite/eslint-plugin-ember-a11y-testing/blob/master/lib/rules/a11y-audit-no-expression.js",
+
+    messages: {
+      a11yAuditMustBeCalled: "a11yAudit must be called as a function and can't be used as a value. Replace `a11yAudit` with added parens, e.g. `a11yAudit()`",
+    },
+    schema: [{
+      "type": "object",
+      "properties": {
+        "auditModule": {
+          "type": "object",
+          "items": {
+            "package": "string",
+            "exportName": "string"
+          }
+        }
+      }
+    }],
+  },
+  create(context) {
+    const options = Array.isArray(context.options) ?
+      context.options[0] && context.options[0].auditModule || {} :
+      {};
+
+    const defaults = {
+      package: 'ember-a11y-testing/test-support/audit',
+      exportName: 'default'
+    };
+    const config = {...defaults, ...options};
+    return {
+      ExpressionStatement: function(node) {
+        const a11yIdentifier = findA11yAuditIdentifier(node.expression, context, config);
+        if (node.expression.type === "Identifier" && node.expression.name === a11yIdentifier) {
+          context.report({
+            node,
+            messageId: "a11yAuditMustBeCalled",
+            fix(fixer) {
+              const functionParent = findParentFunction(node);
+              const prefix = functionParent && functionParent.async ? 'await ' : '';
+              return fixer.replaceText(node.expression, `${prefix}${node.expression.name}()`);
+            }
+          })
+        }
+      },
+      AwaitExpression: function(node) {
+        const a11yIdentifier = findA11yAuditIdentifier(node.argument, context, config);
+        if (node.argument && node.argument.type === "Identifier" && node.argument.name === a11yIdentifier) {
+          context.report({
+            node,
+            messageId: "a11yAuditMustBeCalled",
+            fix(fixer) {
+              return fixer.replaceText(node.argument, `${node.argument.name}()`);
+            }
+          })
+        }
+      }
+    }
+  }
+};
+
+
+function findParentFunction(node) {
+  if (!node) {
+    return node;
+  }
+  if (node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
+    return node;
+  }
+  return findParentFunction(node.parent);
+}
+
+
+/*
+  this is intended to be used to find the name of the emberA11y import name, but in reverse.
+  For example:
+
+  test('my test', function() {
+    await foo();
+    await a11yAudit();
+          ^ tries to figure out the name of the import
+  })
+
+  This makes it so you can copy
+*/
+function findA11yAuditIdentifier(node, context, config) {
+  const defaultImportVariableName = 'a11yAudit'
+  const ref = context.getScope(node).references.find(({identifier: { name }, }) => name === node.name);
+  if (!ref || !ref.resolved) return defaultImportVariableName;
+  const def = ref.resolved.defs.find((def) => {
+    const { type } = def
+    if (type === 'ImportBinding') {
+      if (config.exportName === 'default') {
+        return def.node.type === 'ImportDefaultSpecifier' && def.parent.source.value === config.package
+      } else  {
+        return def.node.type === 'ImportSpecifier' && def.node.imported.name === config.exportName && def.parent.source.value === config.package;
+      }
+    }
+  });
+  return (def && def.name.name) || defaultImportVariableName;
+}

--- a/lib/rules/a11y-audit-no-globals.js
+++ b/lib/rules/a11y-audit-no-globals.js
@@ -56,25 +56,14 @@ module.exports = {
     }
     const config = utils.buildConfig(context.options);
 
-    const importDeclaration = context.getSourceCode().ast.body.find(({type, specifiers, source}) => {
-      return type === 'ImportDeclaration' && source.value === config.auditModule.package;
-    });
-
-    const declaration = importDeclaration && importDeclaration.specifiers.find((specifier) => {
-      if (config.auditModule.exportName === 'default') {
-        return specifier.type === 'ImportDefaultSpecifier';
-      } else {
-        return specifier.type === 'ImportSpecifier' && specifier.imported.name === config.auditModule.exportName;
-      }
-    });
-
-    const a11yAuditIdentifier = declaration ? declaration.local.name : 'a11yAudit';
+    const a11yImportDeclaration = utils.findA11yAuditImportDeclaration(context, config);
+    const a11yAuditIdentifier = a11yImportDeclaration ? a11yImportDeclaration.local.name : 'a11yAudit';
 
     return {
       "CallExpression"(node) {
         let identifier = node.callee.type === 'Identifier' && node.callee;
         if (!identifier || identifier.name !== 'a11yAudit') return
-        if (declaration && a11yAuditIdentifier !== 'a11yAudit') {
+        if (a11yImportDeclaration && a11yAuditIdentifier !== 'a11yAudit') {
           context.report({
             node,
             messageId: "a11yAuditNoGlobalsUseImportName",
@@ -87,7 +76,7 @@ module.exports = {
               return fixer.replaceText(identifier, a11yAuditIdentifier);
             }
           });
-        } else if (!declaration) {
+        } else if (!a11yImportDeclaration) {
           context.report({
             node,
             messageId: "a11yAuditNoGlobals",

--- a/lib/rules/a11y-audit-no-globals.js
+++ b/lib/rules/a11y-audit-no-globals.js
@@ -43,9 +43,9 @@ module.exports = {
     if (!context.getFilename().includes("tests/acceptance")) {
       return {};
     }
-    const config = utils.buildConfig(context.settings);
+    const settings = utils.extractSettings(context);
 
-    const a11yImportDeclaration = utils.findA11yAuditImportDeclaration(context, config);
+    const a11yImportDeclaration = utils.findA11yAuditImportDeclaration(context, settings);
     const a11yAuditIdentifier = a11yImportDeclaration ? a11yImportDeclaration.local.name : 'a11yAudit';
 
     return {
@@ -58,7 +58,7 @@ module.exports = {
             messageId: "a11yAuditNoGlobalsUseImportName",
             data: {
               name: identifier.name,
-              package: config.auditModule.package,
+              package: settings.auditModule.package,
               a11yIdentifier: a11yAuditIdentifier
             },
             fix(fixer) {
@@ -71,26 +71,26 @@ module.exports = {
             messageId: "a11yAuditNoGlobals",
             data: {
               name: identifier.name,
-              package: config.auditModule.package
+              package: settings.auditModule.package
             },
             fix(fixer) {
               const sourceCode = context.getSourceCode();
               let importVariable;
-              if (config.auditModule.exportName === 'default') {
+              if (settings.auditModule.exportName === 'default') {
                 importVariable = `${a11yAuditIdentifier}`;
               } else {
                 let prefix = '';
-                if (config.auditModule.exportName !== 'a11yAudit') {
-                  prefix = `${config.auditModule.exportName} as `
+                if (settings.auditModule.exportName !== 'a11yAudit') {
+                  prefix = `${settings.auditModule.exportName} as `
                 }
                 importVariable = `{ ${prefix}${a11yAuditIdentifier} }`
               }
               const importDeclarations = sourceCode.ast.body.filter(({type}) => type === 'ImportDeclaration');
               const lastImportDeclaration = importDeclarations[importDeclarations.length - 1];
               if (lastImportDeclaration) {
-                return fixer.insertTextAfter(lastImportDeclaration, `\nimport ${importVariable} from '${config.auditModule.package}';\n`, { skipComments: true });
+                return fixer.insertTextAfter(lastImportDeclaration, `\nimport ${importVariable} from '${settings.auditModule.package}';\n`, { skipComments: true });
               }
-              return fixer.insertTextBefore(sourceCode.ast.body[0], `import ${importVariable} from '${config.auditModule.package}';\n`, { skipComments: true });
+              return fixer.insertTextBefore(sourceCode.ast.body[0], `import ${importVariable} from '${settings.auditModule.package}';\n`, { skipComments: true });
             }
           });
         }

--- a/lib/rules/a11y-audit-no-globals.js
+++ b/lib/rules/a11y-audit-no-globals.js
@@ -1,0 +1,122 @@
+"use strict";
+
+const utils = require('../utils');
+
+/**
+ * @fileoverview Enforce a11yAudit must be imported from the desired package.
+ * @author Stanley Stuart <https://github.com/fivetanley>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: "problem",
+    fixable: "code",
+
+    description: "enforce a11yAudit must be imported",
+    category: "Accessibility",
+    recommended: true,
+    url: "https://github.com/jgwhite/eslint-plugin-ember-a11y-testing/blob/master/lib/rules/a11y-audit-no-globals.js",
+
+    schema: [{
+      "type": "object",
+      "properties": {
+        "auditModule": {
+          "type": "object",
+          "items": {
+            "package": "string",
+            "exportName": "string"
+          }
+        }
+      }
+    }],
+
+    parserOptions: {
+      "ecmaVersion": 2017,
+      "sourceType": "module"
+    },
+
+    messages: {
+      a11yAuditNoGlobals: "'{{name}} must be imported from {{package}}",
+      a11yAuditNoGlobalsUseImportName: "'{{name}} is not defined in this file, but {{a11yIdentifier}} is already imported from {{package}}. Change variable name to `{{a11yIdentifier}}` instead"
+    }
+  },
+
+  create(context) {
+    if (!context.getFilename().includes("tests/acceptance")) {
+      return {};
+    }
+    const config = utils.buildConfig(context.options);
+
+    const importDeclaration = context.getSourceCode().ast.body.find(({type, specifiers, source}) => {
+      return type === 'ImportDeclaration' && source.value === config.auditModule.package;
+    });
+
+    const declaration = importDeclaration && importDeclaration.specifiers.find((specifier) => {
+      if (config.auditModule.exportName === 'default') {
+        return specifier.type === 'ImportDefaultSpecifier';
+      } else {
+        return specifier.type === 'ImportSpecifier' && specifier.imported.name === config.auditModule.exportName;
+      }
+    });
+
+    const a11yAuditIdentifier = declaration ? declaration.local.name : 'a11yAudit';
+
+    return {
+      "CallExpression"(node) {
+        let identifier = node.callee.type === 'Identifier' && node.callee;
+        if (!identifier || identifier.name !== 'a11yAudit') return
+        if (declaration && a11yAuditIdentifier !== 'a11yAudit') {
+          context.report({
+            node,
+            messageId: "a11yAuditNoGlobalsUseImportName",
+            data: {
+              name: identifier.name,
+              package: config.auditModule.package,
+              a11yIdentifier: a11yAuditIdentifier
+            },
+            fix(fixer) {
+              return fixer.replaceText(identifier, a11yAuditIdentifier);
+            }
+          });
+        } else if (!declaration) {
+          context.report({
+            node,
+            messageId: "a11yAuditNoGlobals",
+            data: {
+              name: identifier.name,
+              package: config.auditModule.package
+            },
+            fix(fixer) {
+              const sourceCode = context.getSourceCode();
+              let importVariable;
+              if (config.auditModule.exportName === 'default') {
+                importVariable = `${a11yAuditIdentifier}`;
+              } else {
+                let prefix = '';
+                if (config.auditModule.exportName !== 'a11yAudit') {
+                  prefix = `${config.auditModule.exportName} as `
+                }
+                importVariable = `{ ${prefix}${a11yAuditIdentifier} }`
+              }
+              const importDeclarations = sourceCode.ast.body.filter(({type}) => type === 'ImportDeclaration');
+              const lastImportDeclaration = importDeclarations[importDeclarations.length - 1];
+              if (lastImportDeclaration) {
+                return fixer.insertTextAfter(lastImportDeclaration, `\nimport ${importVariable} from '${config.auditModule.package}';\n`, { skipComments: true });
+              }
+              return fixer.insertTextBefore(sourceCode.ast.body[0], `import ${importVariable} from '${config.auditModule.package}';\n`, { skipComments: true });
+            }
+          });
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/a11y-audit-no-globals.js
+++ b/lib/rules/a11y-audit-no-globals.js
@@ -26,21 +26,10 @@ module.exports = {
     recommended: true,
     url: "https://github.com/jgwhite/eslint-plugin-ember-a11y-testing/blob/master/lib/rules/a11y-audit-no-globals.js",
 
-    schema: [{
-      "type": "object",
-      "properties": {
-        "auditModule": {
-          "type": "object",
-          "items": {
-            "package": "string",
-            "exportName": "string"
-          }
-        }
-      }
-    }],
+    schema: [],
 
     parserOptions: {
-      "ecmaVersion": 2017,
+      "ecmaVersion": 2018,
       "sourceType": "module"
     },
 
@@ -54,7 +43,7 @@ module.exports = {
     if (!context.getFilename().includes("tests/acceptance")) {
       return {};
     }
-    const config = utils.buildConfig(context.options);
+    const config = utils.buildConfig(context.settings);
 
     const a11yImportDeclaration = utils.findA11yAuditImportDeclaration(context, config);
     const a11yAuditIdentifier = a11yImportDeclaration ? a11yImportDeclaration.local.name : 'a11yAudit';

--- a/lib/rules/a11y-audit-no-globals.js
+++ b/lib/rules/a11y-audit-no-globals.js
@@ -46,12 +46,12 @@ module.exports = {
     const settings = utils.extractSettings(context);
 
     const a11yImportDeclaration = utils.findA11yAuditImportDeclaration(context, settings);
-    const a11yAuditIdentifier = a11yImportDeclaration ? a11yImportDeclaration.local.name : 'a11yAudit';
+    const a11yAuditIdentifier = a11yImportDeclaration ? a11yImportDeclaration.local.name : utils.DEFAULT_A11Y_AUDIT_VARIABLE;
 
     return {
       "CallExpression"(node) {
         let identifier = node.callee.type === 'Identifier' && node.callee;
-        if (!identifier || identifier.name !== 'a11yAudit') return
+        if (!identifier || identifier.name !== utils.DEFAULT_A11Y_AUDIT_VARIABLE) return
         if (a11yImportDeclaration && a11yAuditIdentifier !== 'a11yAudit') {
           context.report({
             node,
@@ -80,7 +80,7 @@ module.exports = {
                 importVariable = `${a11yAuditIdentifier}`;
               } else {
                 let prefix = '';
-                if (settings.auditModule.exportName !== 'a11yAudit') {
+                if (settings.auditModule.exportName !== utils.DEFAULT_A11Y_AUDIT_VARIABLE) {
                   prefix = `${settings.auditModule.exportName} as `
                 }
                 importVariable = `{ ${prefix}${a11yAuditIdentifier} }`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,7 +35,7 @@ exports.findA11yAuditImportDeclaration = function findA11yAuditImportName(contex
   });
 }
 
-exports.extractSettings = function extratSettings({settings}) {
+exports.extractSettings = function extractSettings({settings}) {
   const providedSettings = settings["ember-a11y-testing"] || {};
 
   const defaults = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,11 +34,9 @@ exports.findA11yAuditImportDeclaration = function findA11yAuditImportName(contex
 }
 
 exports.buildConfig = function buildConfig(rawConfig) {
-  let firstOption = rawConfig[0] || {};
+  const firstOption = rawConfig["ember-a11y-testing"] || {};
 
   const defaults = {
-    include: [],
-    exclude: [],
     auditModule: {
       package: 'ember-a11y-testing/test-support/audit',
       exportName: 'default'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,6 +19,20 @@ exports.findParentOfType = function findParentOfType (node, types) {
   return findParentOfType(node.parent, types);
 }
 
+exports.findA11yAuditImportDeclaration = function findA11yAuditImportName(context, config) {
+  const importDeclaration = context.getSourceCode().ast.body.find(({type, source}) => {
+    return type === 'ImportDeclaration' && source.value === config.auditModule.package;
+  });
+
+  return importDeclaration && importDeclaration.specifiers.find((specifier) => {
+    if (config.auditModule.exportName === 'default') {
+      return specifier.type === 'ImportDefaultSpecifier';
+    } else {
+      return specifier.type === 'ImportSpecifier' && specifier.imported.name === config.auditModule.exportName;
+    }
+  });
+}
+
 exports.buildConfig = function buildConfig(rawConfig) {
   let firstOption = rawConfig[0] || {};
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,35 @@
+exports.findParentOfType = function findParentOfType (node, types) {
+  if (!node) {
+    return node;
+  }
+
+  let typeMatches = false;
+  if (Array.isArray(types)) {
+    typeMatches = types.includes(node.type)
+  } else if (types instanceof RegExp) {
+    typeMatches = types.test(node.type);
+  } else {
+    typeMatches = types === node.type
+  }
+
+  if (typeMatches) {
+    return node;
+  }
+
+  return findParentOfType(node.parent, types);
+}
+
+exports.buildConfig = function buildConfig(rawConfig) {
+  let firstOption = rawConfig[0] || {};
+
+  const defaults = {
+    include: [],
+    exclude: [],
+    auditModule: {
+      package: 'ember-a11y-testing/test-support/audit',
+      exportName: 'default'
+    }
+  }
+
+  return {...defaults, ...firstOption};
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,5 @@
+exports.DEFAULT_A11Y_AUDIT_VARIABLE = 'a11yAudit';
+
 exports.findParentOfType = function findParentOfType (node, types) {
   if (!node) {
     return node;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,8 +33,8 @@ exports.findA11yAuditImportDeclaration = function findA11yAuditImportName(contex
   });
 }
 
-exports.buildConfig = function buildConfig(rawConfig) {
-  const firstOption = rawConfig["ember-a11y-testing"] || {};
+exports.extractSettings = function extratSettings({settings}) {
+  const providedSettings = settings["ember-a11y-testing"] || {};
 
   const defaults = {
     auditModule: {
@@ -43,5 +43,5 @@ exports.buildConfig = function buildConfig(rawConfig) {
     }
   }
 
-  return {...defaults, ...firstOption};
+  return {...defaults, ...providedSettings};
 }

--- a/tests/lib/rules/a11y-audit-no-expression.js
+++ b/tests/lib/rules/a11y-audit-no-expression.js
@@ -1,0 +1,189 @@
+"use strict";
+
+/**
+ * @fileoverview Tests that `a11yAudit` is called as a function. Prevents accidentally comitting code like
+ * `a11yAudit` (no parens, so the audit doens't actually run)
+ * @author Stanley Stuart <https://github.com/fivetanley>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/a11y-audit-no-expression');
+const { RuleTester } = require('eslint/lib/rule-tester');
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const TEST_FILE_NAME = 'tests/acceptance/application-test.js';
+const ruleTester = new RuleTester();
+
+ruleTester.run('a11y-audit-no-expression', rule, {
+  valid: [
+    // visit
+    {
+      code: `visit(); a11yAudit();`,
+      filename: TEST_FILE_NAME
+    },
+    // import alias works
+    {
+      code: `import a11yAudit2 from 'ember-a11y-testing/ember-a11y-testing/test-support/audit'; (async () => { visit(); await a11yAudit2; })`,
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      }
+    },
+    // custom module used
+    {
+      code: 'import { audit } from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); await audit(); } })();',
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      options: [
+        {
+          auditModule: {
+            package: 'dashboard/tests/helpers/audit',
+            exportName: 'audit'
+          }
+        }
+      ]
+    },
+    // custom module used, default import specifier
+    {
+      code: 'import audit from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); await audit(); } })();',
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      options: [
+        {
+          auditModule: {
+            package: 'dashboard/tests/helpers/audit',
+            exportName: 'default'
+          }
+        }
+      ]
+    },
+      // custom module used, default import specifier, but copied to another var
+      {
+        code: 'import audit from "dashboard/tests/helpers/audit"; const audit2 = audit; (async () => { while(true) { visit(); await audit2(); } })();',
+        filename: TEST_FILE_NAME,
+        parserOptions: {
+          ecmaVersion: '2018',
+          sourceType: 'module'
+        },
+        options: [
+          {
+            auditModule: {
+              package: 'dashboard/tests/helpers/audit',
+              exportName: 'default'
+            }
+          }
+        ]
+      }
+  ],
+  invalid: [
+    // import aliases work
+    {
+      code: `import a11yAudit24 from 'ember-a11y-testing/test-support/audit'; (async () => { visit(); await a11yAudit24; })()`,
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      errors: [{ messageId: 'a11yAuditMustBeCalled' }],
+      output: "import a11yAudit24 from 'ember-a11y-testing/test-support/audit'; (async () => { visit(); await a11yAudit24(); })()"
+    },
+    {
+      code: `import a11yAudit24 from 'ember-a11y-testing/test-support/audit'; (async () => { visit(); await a11yAudit24; })()`,
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      errors: [{ messageId: 'a11yAuditMustBeCalled' }],
+      output: "import a11yAudit24 from 'ember-a11y-testing/test-support/audit'; (async () => { visit(); await a11yAudit24(); })()"
+    },
+    // referencing without calling a11yAudit after
+    {
+      code: 'visit(); a11yAudit;',
+      errors: [{ messageId: 'a11yAuditMustBeCalled' }],
+      filename: TEST_FILE_NAME,
+      output: 'visit(); a11yAudit();'
+    },
+    // async function
+    {
+      code: '(async function () { visit(); a11yAudit; })();',
+      errors: [{messageId: 'a11yAuditMustBeCalled'}],
+      output: '(async function () { visit(); await a11yAudit(); })();',
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018'
+      },
+    },
+    // async function with block statements
+    {
+      code: '(async function () { while(true) { visit(); a11yAudit; } })();',
+      errors: [{messageId: 'a11yAuditMustBeCalled'}],
+      output: '(async function () { while(true) { visit(); await a11yAudit(); } })();',
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018'
+      },
+    },
+    // async arrow function
+    {
+      code: '(async () => { while(true) { visit(); a11yAudit; } })();',
+      errors: [{messageId: 'a11yAuditMustBeCalled'}],
+      output: '(async () => { while(true) { visit(); await a11yAudit(); } })();',
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018'
+      },
+    },
+    // custom module used
+    {
+      code: 'import { audit } from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); audit; } })();',
+      errors: [{messageId: 'a11yAuditMustBeCalled'}],
+      output: 'import { audit } from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); await audit(); } })();',
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      options: [
+        {
+          auditModule: {
+            package: 'dashboard/tests/helpers/audit',
+            exportName: 'audit'
+          }
+        }
+      ]
+    },
+    // custom module used, default import specifier
+    {
+      code: 'import audit from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); audit; } })();',
+      errors: [{messageId: 'a11yAuditMustBeCalled'}],
+      output: 'import audit from "dashboard/tests/helpers/audit"; (async () => { while(true) { visit(); await audit(); } })();',
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      options: [
+        {
+          auditModule: {
+            package: 'dashboard/tests/helpers/audit',
+            exportName: 'default'
+          }
+        }
+      ]
+    }
+  ]
+});

--- a/tests/lib/rules/a11y-audit-no-expression.js
+++ b/tests/lib/rules/a11y-audit-no-expression.js
@@ -44,14 +44,14 @@ ruleTester.run('a11y-audit-no-expression', rule, {
         ecmaVersion: '2018',
         sourceType: 'module'
       },
-      options: [
-        {
+      settings: {
+        "ember-a11y-testing": {
           auditModule: {
             package: 'dashboard/tests/helpers/audit',
             exportName: 'audit'
           }
         }
-      ]
+      }
     },
     // custom module used, default import specifier
     {
@@ -61,14 +61,14 @@ ruleTester.run('a11y-audit-no-expression', rule, {
         ecmaVersion: '2018',
         sourceType: 'module'
       },
-      options: [
-        {
+      settings: {
+        "ember-a11y-testing": {
           auditModule: {
             package: 'dashboard/tests/helpers/audit',
             exportName: 'default'
           }
         }
-      ]
+      }
     },
       // custom module used, default import specifier, but copied to another var
       {
@@ -78,14 +78,14 @@ ruleTester.run('a11y-audit-no-expression', rule, {
           ecmaVersion: '2018',
           sourceType: 'module'
         },
-        options: [
-          {
+        settings: {
+          "ember-a11y-testing": {
             auditModule: {
               package: 'dashboard/tests/helpers/audit',
               exportName: 'default'
             }
           }
-        ]
+        }
       }
   ],
   invalid: [
@@ -157,14 +157,14 @@ ruleTester.run('a11y-audit-no-expression', rule, {
         ecmaVersion: '2018',
         sourceType: 'module'
       },
-      options: [
-        {
+      settings: {
+        "ember-a11y-testing": {
           auditModule: {
             package: 'dashboard/tests/helpers/audit',
             exportName: 'audit'
           }
         }
-      ]
+      }
     },
     // custom module used, default import specifier
     {
@@ -176,14 +176,14 @@ ruleTester.run('a11y-audit-no-expression', rule, {
         ecmaVersion: '2018',
         sourceType: 'module'
       },
-      options: [
-        {
+      settings: {
+        "ember-a11y-testing": {
           auditModule: {
             package: 'dashboard/tests/helpers/audit',
             exportName: 'default'
           }
         }
-      ]
+      }
     }
   ]
 });

--- a/tests/lib/rules/a11y-audit-no-globals.js
+++ b/tests/lib/rules/a11y-audit-no-globals.js
@@ -45,12 +45,14 @@ ruleTester.run('a11y-audit-no-globals', rule, {
         ecmaVersion: '2018',
         sourceType: 'module'
       },
-      options: [{
-        auditModule: {
-          package: 'custom-module',
-          exportName: 'default'
+      settings: {
+        "ember-a11y-testing": {
+          auditModule: {
+            package: 'custom-module',
+            exportName: 'default'
+          }
         }
-      }]
+      }
     }
   ],
   invalid: [
@@ -83,12 +85,14 @@ ruleTester.run('a11y-audit-no-globals', rule, {
         ecmaVersion: '2018',
         sourceType: 'module'
       },
-      options: [{
-        auditModule: {
-          package: 'custom-module',
-          exportName: 'a11yAudit2'
+      settings: {
+        "ember-a11y-testing": {
+          auditModule: {
+            package: 'custom-module',
+            exportName: 'a11yAudit2'
+          }
         }
-      }]
+      }
     },
     {
       code: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit();`,
@@ -119,12 +123,14 @@ ruleTester.run('a11y-audit-no-globals', rule, {
         ecmaVersion: '2018',
         sourceType: 'module'
       },
-      options: [{
-        auditModule: {
-          package: 'custom-module',
-          exportName: 'default'
+      settings: {
+        "ember-a11y-testing": {
+          auditModule: {
+            package: 'custom-module',
+            exportName: 'default'
+          }
         }
-      }]
+      }
     },
     {
       code: `import { a11yAudit2 } from 'custom-module'; a11yAudit();`,
@@ -135,12 +141,14 @@ ruleTester.run('a11y-audit-no-globals', rule, {
         ecmaVersion: '2018',
         sourceType: 'module'
       },
-      options: [{
-        auditModule: {
-          package: 'custom-module',
-          exportName: 'a11yAudit2'
+      settings: {
+        "ember-a11y-testing": {
+          auditModule: {
+            package: 'custom-module',
+            exportName: 'a11yAudit2'
+          }
         }
-      }]
+      }
     }
   ]
 });

--- a/tests/lib/rules/a11y-audit-no-globals.js
+++ b/tests/lib/rules/a11y-audit-no-globals.js
@@ -1,0 +1,146 @@
+"use strict";
+
+/**
+ * @fileoverview Tests that `a11yAudit` is called as a function. Prevents accidentally comitting code like
+ * `a11yAudit` (no parens, so the audit doens't actually run)
+ * @author Stanley Stuart <https://github.com/fivetanley>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/a11y-audit-no-globals');
+const { RuleTester } = require('eslint/lib/rule-tester');
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const TEST_FILE_NAME = 'tests/acceptance/application-test.js';
+const ruleTester = new RuleTester();
+
+ruleTester.run('a11y-audit-no-globals', rule, {
+  valid: [
+    {
+      code: `import a11yAudit from 'ember-a11y-testing/test-support/audit'; a11yAudit();`,
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit2();`,
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `import a11yAudit2 from 'custom-module'; a11yAudit2();`,
+      filename: TEST_FILE_NAME,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      options: [{
+        auditModule: {
+          package: 'custom-module',
+          exportName: 'default'
+        }
+      }]
+    }
+  ],
+  invalid: [
+    {
+      code: `a11yAudit();`,
+      filename: TEST_FILE_NAME,
+      errors: [{messageId: 'a11yAuditNoGlobals'}],
+      output: `import a11yAudit from 'ember-a11y-testing/test-support/audit';\na11yAudit();`,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `/* existing import with comments */\nimport Blah from 'blah';\nimport Foo from 'foo'; a11yAudit();`,
+      filename: TEST_FILE_NAME,
+      errors: [{messageId: 'a11yAuditNoGlobals'}],
+      output: `/* existing import with comments */\nimport Blah from 'blah';\nimport Foo from 'foo';\nimport a11yAudit from 'ember-a11y-testing/test-support/audit';\n a11yAudit();`,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `a11yAudit();`,
+      filename: TEST_FILE_NAME,
+      errors: [{messageId: 'a11yAuditNoGlobals'}],
+      output: `import { a11yAudit2 as a11yAudit } from 'custom-module';\na11yAudit();`,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      options: [{
+        auditModule: {
+          package: 'custom-module',
+          exportName: 'a11yAudit2'
+        }
+      }]
+    },
+    {
+      code: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit();`,
+      filename: TEST_FILE_NAME,
+      errors: [{messageId: 'a11yAuditNoGlobalsUseImportName'}],
+      output: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit2();`,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit();`,
+      filename: TEST_FILE_NAME,
+      errors: [{messageId: 'a11yAuditNoGlobalsUseImportName'}],
+      output: `import a11yAudit2 from 'ember-a11y-testing/test-support/audit'; a11yAudit2();`,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      }
+    },
+    {
+      code: `import a11yAudit2 from 'custom-module'; a11yAudit();`,
+      filename: TEST_FILE_NAME,
+      errors: [{messageId: 'a11yAuditNoGlobalsUseImportName'}],
+      output: `import a11yAudit2 from 'custom-module'; a11yAudit2();`,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      options: [{
+        auditModule: {
+          package: 'custom-module',
+          exportName: 'default'
+        }
+      }]
+    },
+    {
+      code: `import { a11yAudit2 } from 'custom-module'; a11yAudit();`,
+      filename: TEST_FILE_NAME,
+      errors: [{messageId: 'a11yAuditNoGlobalsUseImportName'}],
+      output: `import { a11yAudit2 } from 'custom-module'; a11yAudit2();`,
+      parserOptions: {
+        ecmaVersion: '2018',
+        sourceType: 'module'
+      },
+      options: [{
+        auditModule: {
+          package: 'custom-module',
+          exportName: 'a11yAudit2'
+        }
+      }]
+    }
+  ]
+});


### PR DESCRIPTION
will update this tomorrow but at a brief glance...

## Add autofixing

Adds a `fix` function to each call to `context.report`, so that we can take advantage of eslint's autofix feature. Here's a gif showing off the integration with VSCode's eslint integration.

![autofix3](https://user-images.githubusercontent.com/1275021/80457338-fbb33180-88e3-11ea-9040-3f9b567fa7e7.gif)

The autofixing rules will also fix missing imports, so it should be as easy as saving your editor to get all the `a11yAudit` and their `import` in the file.

## Refactor: Move checks for making sure `a11yAudit()` is actually called to its own file

According to the [Rule docs for applying fixes](https://eslint.org/docs/developer-guide/working-with-rules#applying-fixes), we should make each autofix as small scoped as possible. Indeed, ESLint enforces this by making you able to return only one call to the fixer. I moved the checks that ensure that `await a11yAudit;` and `a11yAudit` (no parens, so no function gets invoked) to its own file so we could autofix it.

## Specify a custom module

If you're bringing in axe piecemeal, or have other integrations for your audit, it might be useful to be able to specify a custom module instead of `a11yAudit` directly. For example, adding a config of:

```javascript
[{
  auditModule: {
    package: 'dashboard/tests/helpers/a11y-audit'.
    exportName: 'default'
  }
}]
```

will use

```javascript
import a11yAudit from 'dashboard/tests/helpers/a11y-audit';
```

for the imports.


